### PR TITLE
Align navbar to left in header

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -17,16 +17,16 @@
         <h1 class="display-4">Nubescribe</h1>
         <p class="lead">Donde las ideas vuelan</p>
       </div>
-      <nav class="navbar navbar-expand-lg navbar-light bg-light">
-				 
-				<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-					<span class="navbar-toggler-icon"></span>
-                                </button> <a class="navbar-brand" href="EntregaFinal.html"><img src="../nubescribe.png" height="60" width="60" alt="Descripción de la imagen"  title="Nubescribe"></a>
-				<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-					<ul class="navbar-nav">
-						<li class="nav-item active">
+      <nav class="col navbar navbar-expand-lg navbar-light bg-light justify-content-start">
+                                <a class="navbar-brand" href="EntregaFinal.html"><img src="../nubescribe.png" height="60" width="60" alt="Descripción de la imagen"  title="Nubescribe"></a>
+                                <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-controls="bs-example-navbar-collapse-1" aria-expanded="false" aria-label="Toggle navigation">
+                                        <span class="navbar-toggler-icon"></span>
+                                </button>
+                                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+                                        <ul class="navbar-nav">
+                                                <li class="nav-item active">
                                                          <a class="nav-link" href="../index.html">Regresar <span class="sr-only"></span></a>
-						</li>
+                                                </li>
 						<li class="nav-item">
                                                          <a class="nav-link" href="nosotros.html">Nosotros</a>
 						</li>


### PR DESCRIPTION
## Summary
- Align header navigation bar to the left and ensure it expands correctly
- Reordered brand and toggle button, and added grid column styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890daa429d08327963e4dd37559c298