### PR TITLE
Refactor header layout and fix carousel description sync

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -12,39 +12,34 @@
 <body>
   <div class="container">
     <!-- =================== HEADER =================== -->
-    <header class="row py-4">
-      <div class="col text-center">
-        <h1 class="display-4">Nubescribe</h1>
-        <p class="lead">Donde las ideas vuelan</p>
-      </div>
-      <nav class="col navbar navbar-expand-lg navbar-light bg-light justify-content-start">
-                                <a class="navbar-brand" href="EntregaFinal.html"><img src="../nubescribe.png" height="60" width="60" alt="Descripción de la imagen"  title="Nubescribe"></a>
-                                <button class="navbar-toggler ml-auto" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-controls="bs-example-navbar-collapse-1" aria-expanded="false" aria-label="Toggle navigation">
-                                        <span class="navbar-toggler-icon"></span>
-                                </button>
-                                <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-                                        <ul class="navbar-nav">
-                                                <li class="nav-item active">
-                                                         <a class="nav-link" href="../index.html">Regresar <span class="sr-only"></span></a>
-                                                </li>
-						<li class="nav-item">
-                                                         <a class="nav-link" href="nosotros.html">Nosotros</a>
-						</li>
-
-					</ul>
-					<form class="form-inline">
-						<input class="form-control mr-sm-2" type="text" /> 
-
-					</form>
-					<ul class="navbar-nav ml-md-auto">
-						<li class="nav-item active" id="miperfil">
-							 <a class="nav-link" href="#">Mi Perfil<span class="sr-only"></span></a>
-						</li>
-						
-					</ul>
-				</div>
-			</nav>
+    <header class="py-4 d-flex justify-content-center">
+      <img src="../nubescribe.png" alt="Nubescribe" class="img-fluid" width="120">
     </header>
+
+    <!-- =================== NAVBAR =================== -->
+    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContenido" aria-controls="navbarContenido" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarContenido">
+        <ul class="navbar-nav">
+          <li class="nav-item active">
+            <a class="nav-link" href="../index.html">Regresar <span class="sr-only"></span></a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="nosotros.html">Nosotros</a>
+          </li>
+        </ul>
+        <form class="form-inline ml-auto mr-md-2">
+          <input class="form-control" type="text" />
+        </form>
+        <ul class="navbar-nav">
+          <li class="nav-item active" id="miperfil">
+            <a class="nav-link" href="#">Mi Perfil<span class="sr-only"></span></a>
+          </li>
+        </ul>
+      </div>
+    </nav>
 
     <!-- =================== MAIN CONTENT =================== -->
     <main class="row">
@@ -117,13 +112,12 @@
   <script src="js/scripts.js"></script>
   <script>
     // Script para actualizar la descripción del libro al cambiar de slide
-    const carousel = document.getElementById('carouselLibros');
-    const descripcion = document.getElementById('descripcionLibro');
-
-    carousel.addEventListener('slid.bs.carousel', function () {
-      const activeItem = carousel.querySelector('.carousel-item.active');
-      const newDescription = activeItem.getAttribute('data-description');
-      descripcion.textContent = newDescription;
+    $(document).ready(function () {
+      $('#carouselLibros').on('slid.bs.carousel', function () {
+        const activeItem = $(this).find('.carousel-item.active');
+        const newDescription = activeItem.data('description');
+        $('#descripcionLibro').text(newDescription);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Center logo in header and move navigation bar below for a flexible banner
- Update carousel script to refresh description text with active slide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890dcbb5c448327a11fd2ecfbc63ecf