### PR TITLE
feat: expand navbar without toggle

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -17,28 +17,23 @@
     </header>
 
     <!-- =================== NAVBAR =================== -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContenido" aria-controls="navbarContenido" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarContenido">
-        <ul class="navbar-nav">
-          <li class="nav-item active">
-            <a class="nav-link" href="../index.html">Regresar <span class="sr-only"></span></a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="nosotros.html">Nosotros</a>
-          </li>
-        </ul>
-        <form class="form-inline ml-auto mr-md-2">
-          <input class="form-control" type="text" />
-        </form>
-        <ul class="navbar-nav">
-          <li class="nav-item active" id="miperfil">
-            <a class="nav-link" href="#">Mi Perfil<span class="sr-only"></span></a>
-          </li>
-        </ul>
-      </div>
+    <nav class="navbar navbar-light bg-light mb-4 flex-row justify-content-between">
+      <ul class="navbar-nav flex-row">
+        <li class="nav-item active">
+          <a class="nav-link" href="../index.html">Regresar <span class="sr-only"></span></a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="nosotros.html">Nosotros</a>
+        </li>
+      </ul>
+      <form class="form-inline">
+        <input class="form-control" type="text" />
+      </form>
+      <ul class="navbar-nav flex-row">
+        <li class="nav-item active" id="miperfil">
+          <a class="nav-link" href="#">Mi Perfil<span class="sr-only"></span></a>
+        </li>
+      </ul>
     </nav>
 
     <!-- =================== MAIN CONTENT =================== -->


### PR DESCRIPTION
## Summary
- display navigation links directly instead of collapse button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890de0534dc83279408975355a358f4