### PR TITLE
Reduce header size, match footer color, and add logo glow

### DIFF
--- a/Proyecto2/Pagina_Principal/js/scripts.js
+++ b/Proyecto2/Pagina_Principal/js/scripts.js
@@ -1,1 +1,10 @@
-// Empty JS for your own code to be here
+$(function() {
+    $('.navbar-brand img').hover(
+        function() {
+            $(this).css('box-shadow', '0 0 10px 2px rgba(255, 215, 0, 0.6)');
+        },
+        function() {
+            $(this).css('box-shadow', 'none');
+        }
+    );
+});

--- a/Proyecto2/Pagina_Principal/main2.html
+++ b/Proyecto2/Pagina_Principal/main2.html
@@ -11,9 +11,9 @@
 
 </head>
 <body>
-  <div class="container">
-    <!-- =================== HEADER =================== -->
-    <header class="row py-4">
+    <div class="container">
+      <!-- =================== HEADER =================== -->
+      <header class="row">
       <div class="col text-center">
         <h1 class="display-4">Nubescribe</h1>
         <p class="lead">Donde las ideas vuelan</p>
@@ -111,8 +111,10 @@
     </footer>
   </div>
 
-  <!-- Bootstrap JS Bundle con Popper -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Bootstrap JS Bundle con Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/Proyecto2/Pagina_Principal/js/jquery.min.js"></script>
+    <script src="/Proyecto2/Pagina_Principal/js/scripts.js"></script>
   <script>
     // Script para actualizar la descripción del libro al cambiar de slide
     const carousel = document.getElementById('carouselLibros');

--- a/Proyecto2/style.css
+++ b/Proyecto2/style.css
@@ -6,6 +6,21 @@ body {
 
 header {
     background-color: rgb(218, 228, 238);
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+header.py-4 {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+footer {
+    background-color: rgb(218, 228, 238);
+}
+
+.navbar-brand img {
+    transition: box-shadow 0.3s ease;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- Reduce header padding to shrink height and apply matching background color to footer
- Add jQuery and transition styles to create a subtle golden glow on the header logo on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e83a341c8327ac827c72038c9db2