### PR TITLE
Adjust Nubescribe header logo size

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -13,7 +13,7 @@
   <div class="container">
     <!-- =================== HEADER =================== -->
     <header class="py-4 d-flex justify-content-center">
-      <img src="../nubescribe.png" alt="Nubescribe" class="img-fluid" width="120">
+      <img src="../nubescribe.png" alt="Nubescribe" class="img-fluid" width="100" height="100">
     </header>
 
     <!-- =================== NAVBAR =================== -->


### PR DESCRIPTION
## Summary
- Resize header logo to 100x100 for consistent layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f38041e483279c0f04291d5b3189