### PR TITLE
Reduce header image size

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -13,7 +13,7 @@
   <div class="container">
     <!-- =================== HEADER =================== -->
     <header class="py-4 d-flex justify-content-center">
-      <img src="../nubescribe.png" alt="Nubescribe" class="img-fluid" width="100" height="100">
+      <img src="../nubescribe.png" alt="Nubescribe" class="img-fluid">
     </header>
 
     <!-- =================== NAVBAR =================== -->

--- a/EntregaFinal/style.css
+++ b/EntregaFinal/style.css
@@ -9,7 +9,7 @@ header {
     padding: 0.5rem 0 !important;
 }
 
-header img {
+header img.img-fluid {
     height: 40px;
     width: auto;
     transition: box-shadow 0.3s ease;


### PR DESCRIPTION
## Summary
- Remove fixed width and height attributes from header logo in main page
- Use a more specific CSS selector to size the Bootstrap img-fluid header logo to 40px tall

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6890f592ef9083278316e13a31b0e073