### PR TITLE
Ajusta el tamaño de las imágenes del carrusel de Destacados

### DIFF
--- a/EntregaFinal/style.css
+++ b/EntregaFinal/style.css
@@ -99,6 +99,8 @@ h3 {
 }
 
 .carousel-item img {
+    height: 200px;
+    object-fit: cover;
     transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- Normaliza el alto de las imágenes del carrusel y ajusta su encuadre para que todas se vean del mismo tamaño

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891066fa5248327a8de8fa9756916e5