### PR TITLE
Ajusta el tamaño de las imágenes de Historias Destacadas

### DIFF
--- a/EntregaFinal/style.css
+++ b/EntregaFinal/style.css
@@ -99,6 +99,8 @@ h3 {
 }
 
 .carousel-item img {
+    height: 200px;
+    object-fit: cover;
     transition: transform 0.3s ease;
 }
 
@@ -121,6 +123,9 @@ h3 {
 
 .taller-section img {
     border-radius: 0.25rem;
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
 }
 
 .taller-section p {


### PR DESCRIPTION
## Summary
- Fuerza un tamaño uniforme para las imágenes de "Historias Destacadas" y recorta el contenido para mantener proporciones consistentes.

## Testing
- `npm test` *(falla: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/EntregaN2/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6891066fa5248327a8de8fa9756916e5