### PR TITLE
Restrict hover preview to carousel images

### DIFF
--- a/EntregaFinal/Pagina_Principal/EntregaFinal.html
+++ b/EntregaFinal/Pagina_Principal/EntregaFinal.html
@@ -74,23 +74,23 @@
                 <div class="carousel-inner">
                   <!-- Slide 1 -->
                   <div class="carousel-item active" data-description="Todas las Hadas del Reino: Este es un libro de aventuras emocionante.">
-                    <img src="por1.jpg" class="d-block w-100 h-200" alt="Portada del Libro 1 - Aventuras" loading="lazy">
+                    <img src="por1.jpg" class="previewable-img d-block w-100 h-200" alt="Portada del Libro 1 - Aventuras" loading="lazy">
                   </div>
                   <!-- Slide 2 -->
                   <div class="carousel-item" data-description="Huellas de un Amor: Una novela romántica cautivadora.">
-                    <img src="por2.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 2 - Novela Romántica" loading="lazy">
+                    <img src="por2.jpeg" class="previewable-img d-block w-100 h-200" alt="Portada del Libro 2 - Novela Romántica" loading="lazy">
                   </div>
                   <!-- Slide 3 -->
                   <div class="carousel-item" data-description="He Can See You: Un libro de misterio intrigante.">
-                    <img src="por3.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 3 - Misterio" loading="lazy">
+                    <img src="por3.jpeg" class="previewable-img d-block w-100 h-200" alt="Portada del Libro 3 - Misterio" loading="lazy">
                   </div>
                   <!-- Slide 4 -->
                   <div class="carousel-item" data-description="El Poder de la Accion: Una biografía inspiradora.">
-                    <img src="por4.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 4 - Biografía" loading="lazy">
+                    <img src="por4.jpeg" class="previewable-img d-block w-100 h-200" alt="Portada del Libro 4 - Biografía" loading="lazy">
                   </div>
                   <!-- Slide 5 -->
                   <div class="carousel-item" data-description="Aventuras en el Amazonas: Una colección de cuentos cortos.">
-                    <img src="por5.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 5 - Cuentos Cortos" loading="lazy">
+                    <img src="por5.jpeg" class="previewable-img d-block w-100 h-200" alt="Portada del Libro 5 - Cuentos Cortos" loading="lazy">
                   </div>
                 </div>
                 <!-- Controles del Carrusel -->

--- a/EntregaFinal/Pagina_Principal/js/scripts.js
+++ b/EntregaFinal/Pagina_Principal/js/scripts.js
@@ -31,7 +31,7 @@ $(document).ready(function () {
   );
 
   // Image hover preview
-  $('img').hover(
+  $('img.previewable-img').hover(
     function (e) {
       const src = $(this).attr('src');
       const preview = $('<div class="image-hover-preview"><img src="' + src + '" alt="preview"></div>');
@@ -43,7 +43,7 @@ $(document).ready(function () {
     }
   );
 
-  $('img').mousemove(function (e) {
+  $('img.previewable-img').mousemove(function (e) {
     $('.image-hover-preview').css({ top: e.pageY + 10, left: e.pageX + 10 });
   });
 


### PR DESCRIPTION
## Summary
- add `previewable-img` class to carousel images and ensure other sections omit it
- limit hover preview script to `img.previewable-img`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911ea79fac8327b55c7a86e32c9073