### PR TITLE
Aumentar altura de imágenes en carrusel

### DIFF
--- a/Proyecto2/Pagina_Principal/main2.html
+++ b/Proyecto2/Pagina_Principal/main2.html
@@ -60,23 +60,23 @@
                 <div class="carousel-inner">
                   <!-- Slide 1 -->
                   <div class="carousel-item active" data-description="Todas las Hadas del Reino: Este es un libro de aventuras emocionante.">
-                    <img src="/Proyecto2/Pagina_Principal/por1.jpg" class="d-block w-100 h-200" alt="Portada del Libro 1 - Aventuras">
+                    <img src="/Proyecto2/Pagina_Principal/por1.jpg" class="d-block w-100 h-400" alt="Portada del Libro 1 - Aventuras">
                   </div>
                   <!-- Slide 2 -->
                   <div class="carousel-item" data-description="Huellas de un Amor: Una novela romántica cautivadora.">
-                    <img src="/Proyecto2/Pagina_Principal/por2.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 2 - Novela Romántica">
+                    <img src="/Proyecto2/Pagina_Principal/por2.jpeg" class="d-block w-100 h-400" alt="Portada del Libro 2 - Novela Romántica">
                   </div>
                   <!-- Slide 3 -->
                   <div class="carousel-item" data-description="He Can See You: Un libro de misterio intrigante.">
-                    <img src="/Proyecto2/Pagina_Principal/por3.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 3 - Misterio">
+                    <img src="/Proyecto2/Pagina_Principal/por3.jpeg" class="d-block w-100 h-400" alt="Portada del Libro 3 - Misterio">
                   </div>
                   <!-- Slide 4 -->
                   <div class="carousel-item" data-description="El Poder de la Accion: Una biografía inspiradora.">
-                    <img src="/Proyecto2/Pagina_Principal/por4.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 4 - Biografía">
+                    <img src="/Proyecto2/Pagina_Principal/por4.jpeg" class="d-block w-100 h-400" alt="Portada del Libro 4 - Biografía">
                   </div>
                   <!-- Slide 5 -->
                   <div class="carousel-item" data-description="Aventuras en el Amazonas: Una colección de cuentos cortos.">
-                    <img src="/Proyecto2/Pagina_Principal/por5.jpeg" class="d-block w-100 h-200" alt="Portada del Libro 5 - Cuentos Cortos">
+                    <img src="/Proyecto2/Pagina_Principal/por5.jpeg" class="d-block w-100 h-400" alt="Portada del Libro 5 - Cuentos Cortos">
                   </div>
                 </div>
                 <!-- Controles del Carrusel -->

--- a/Proyecto2/style.css
+++ b/Proyecto2/style.css
@@ -71,8 +71,13 @@ h3 {
 .contenedor-generos {
     margin-left: 10%;
     display: flex;
-    justify-content: space-between;  
+    justify-content: space-between;
     margin-right: 10%;
+}
+
+/* Altura del carrusel: duplica la altura sin afectar el ancho */
+.h-400 {
+    height: 400px;
 }
 
 


### PR DESCRIPTION
## Summary
- Duplica la altura de las imágenes del carrusel manteniendo su ancho completo.
- Añade utilidad CSS `h-400` para controlar la altura de las portadas.

## Testing
- `npm test` *(falla: falta package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891310c267883279f371c5df88eaff6