### PR TITLE
Increase carousel image height

### DIFF
--- a/EntregaFinal/style.css
+++ b/EntregaFinal/style.css
@@ -99,7 +99,7 @@ h3 {
 }
 
 .carousel-item img {
-    height: 200px;
+    height: 300px;
     object-fit: cover;
     transition: transform 0.3s ease;
 }
@@ -124,7 +124,7 @@ h3 {
 .taller-section img {
     border-radius: 0.25rem;
     width: 100%;
-    height: 200px;
+    height: 400px;
     object-fit: cover;
 }
 

--- a/EntregaFinal/style.scss
+++ b/EntregaFinal/style.scss
@@ -103,7 +103,7 @@ h3 {
   overflow: hidden;
 
   img {
-    height: 200px;
+    height: 300px;
     object-fit: cover;
     transition: transform 0.3s ease;
 
@@ -127,7 +127,7 @@ h3 {
   img {
     border-radius: 0.25rem;
     width: 100%;
-    height: 200px;
+    height: 400px;
     object-fit: cover;
   }
 


### PR DESCRIPTION
## Summary
- set carousel images to 300px tall while keeping full width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891342939ac8327975c42c7de32bf58